### PR TITLE
Force iOS UISlider to work with discrete steps

### DIFF
--- a/cars/car-detail-edit-page/car-detail-edit-page.xml
+++ b/cars/car-detail-edit-page/car-detail-edit-page.xml
@@ -25,7 +25,7 @@
                         </FormattedString>
                     </Label>
                 </GridLayout>
-                <Slider value="{{ car.price }}" />
+                <Slider value="{{ car.price, car.price | roundingValueConverter }}" />
 
                 <Label text="ADD OR REMOVE IMAGE" />
                 <!--
@@ -67,7 +67,7 @@
                         </FormattedString>
                     </Label>
                 </GridLayout>
-                <Slider minValue="{{ carLuggageMinValue }}" maxValue="{{ carLuggageMaxValue }}" value="{{ car.luggage }}" />
+                <Slider minValue="0" maxValue="5" value="{{ car.luggage, car.luggage | roundingValueConverter }}" />
 
             </StackLayout>
         </ScrollView>

--- a/cars/car-detail-edit-page/car-detail-edit-view-model.js
+++ b/cars/car-detail-edit-page/car-detail-edit-view-model.js
@@ -4,6 +4,8 @@ const permissions = require("nativescript-permissions");
 const platform = require("tns-core-modules/platform");
 const firebase = require("nativescript-plugin-firebase");
 
+const RoundingValueConverter = require("./roundingValueConverter");
+
 const faPlusIcon = "\uf067";
 const faThrashIcon = "\uf014";
 
@@ -13,11 +15,11 @@ function CarDetailEditViewModel(carModel) {
     viewModel.car = carModel;
     viewModel.addRemoveText = faThrashIcon;
 
-    viewModel.carLuggageMinValue = 0;
-    viewModel.carLuggageMaxValue = 5;
-
     viewModel.isUpdating = false;
     viewModel._isCarImageDirty = false;
+
+    // set up value converter to force iOS UISlider to work with discrete steps
+    viewModel.roundingValueConverter = new RoundingValueConverter();
 
     viewModel.onImageAddRemove = function () {
         if (this.car.imageUrl) {

--- a/cars/car-detail-edit-page/roundingValueConverter.js
+++ b/cars/car-detail-edit-page/roundingValueConverter.js
@@ -1,0 +1,11 @@
+function RoundingValueConverter() {}
+
+RoundingValueConverter.prototype.toView = function (value) {
+    return value;
+};
+
+RoundingValueConverter.prototype.toModel = function (value) {
+    return Math.round(value);
+};
+
+module.exports = RoundingValueConverter;


### PR DESCRIPTION
Force iOS UISlider instances on "Edit" screen (luggage, price per day) to work with discrete steps as is the default behavior in Android (and expected behavior in this scenario).