### PR TITLE
Clean up code with imagepicker plugin update

### DIFF
--- a/cars/car-detail-edit-page/car-detail-edit-view-model.js
+++ b/cars/car-detail-edit-page/car-detail-edit-view-model.js
@@ -1,12 +1,9 @@
 const observableModule = require("data/observable");
 const imagePicker = require("nativescript-imagepicker");
-const permissions = require("nativescript-permissions");
-const platform = require("tns-core-modules/platform");
 
 const CarService = require("../shared/car-service");
 const roundingValueConverter = require("./roundingValueConverter");
 const visibilityValueConverter = require("./visibilityValueConverter");
-
 
 function CarDetailEditViewModel(carModel) {
     const viewModel = observableModule.fromObject({
@@ -35,14 +32,11 @@ function CarDetailEditViewModel(carModel) {
                 mode: "single"
             });
 
-            let queue = Promise.resolve();
-
-            // lower SDK versions will grant permission from AndroidManifest file
-            if (platform.device.os === "Android" && Number(platform.device.sdkVersion) >= 23) {
-                queue = queue.then(() => permissions.requestPermission("android.permission.READ_EXTERNAL_STORAGE"));
-            }
-
-            queue.then(() => this._startSelection(context))
+            context
+                .authorize()
+                .then(() => context.present())
+                .then((selection) => selection.forEach(
+                    (selectedImage) => this._handleImageChange(selectedImage.fileUri)))
                 .catch((errorMessage) => console.log(errorMessage));
         },
 
@@ -95,14 +89,6 @@ function CarDetailEditViewModel(carModel) {
             // raise property change event here so binding in
             // /cars/car-detail-edit-page/my-image-add-remove/MyImageAddRemove.xml works correctly
             this.car.set("imageUrl", value);
-        },
-
-        _startSelection: function (context) {
-            context
-                .authorize()
-                .then(() => context.present())
-                .then((selection) => selection.forEach((selectedImage) => this._handleImageChange(selectedImage.fileUri)))
-                .catch((errorMessage) => console.log(errorMessage));
         }
     });
 

--- a/cars/shared/car-service.js
+++ b/cars/shared/car-service.js
@@ -54,8 +54,7 @@ function CarService() {
         if (data) {
             for (const id in data) {
                 if (data.hasOwnProperty(id)) {
-                    const result = Object.assign({ id }, data[id]);
-                    this._cars.push(new Car(result));
+                    this._cars.push(new Car(data[id]));
                 }
             }
         }

--- a/package.json
+++ b/package.json
@@ -27,8 +27,7 @@
     "v8Flags": "--expose_gc"
   },
   "dependencies": {
-    "nativescript-imagepicker": "^3.0.1",
-    "nativescript-permissions": "^1.2.3",
+    "nativescript-imagepicker": "~3.0.3",
     "nativescript-plugin-firebase": "^3.12.0",
     "nativescript-telerik-ui": "^3.0.0",
     "nativescript-theme-core": "~1.0.2",


### PR DESCRIPTION
Latest version 3.0.3 of nativescript-imagepicker plugin incorporates the logic for Android 6 & 7 permissions https://github.com/NativeScript/nativescript-imagepicker/issues/66 so we can remove it from our code.

Same approach as https://github.com/NativeScript/template-master-detail-ng/pull/52