### PR TITLE
Clear navigation history when navigate from edit page 

### DIFF
--- a/cars/car-detail-edit-page/car-detail-edit-page.js
+++ b/cars/car-detail-edit-page/car-detail-edit-page.js
@@ -52,6 +52,7 @@ function onDoneButtonTap(args) {
         .then(() => topmost().navigate({ 
             moduleName: "cars/cars-list-page",
             animated: true,
+            clearHistory: true,
             transition: {
                 name: "slideBottom",
                 duration: 200,
@@ -72,13 +73,14 @@ function onDoneButtonTap(args) {
     const readOnlyMessage = "Check out the \"Firebase database setup\" section in the readme file to make it editable.";
     const queue = Promise.resolve();
     queue.then(() => alert({
-            title: "Read-Only Template!",
-            message: readOnlyMessage,
-            okButtonText: "Ok"
-        }))
+        title: "Read-Only Template!",
+        message: readOnlyMessage,
+        okButtonText: "Ok"
+    }))
         .then(() => topmost().navigate({
             moduleName: "cars/cars-list-page",
             animated: true,
+            clearHistory: true,
             transition: {
                 name: "slideBottom",
                 duration: 200,


### PR DESCRIPTION
Clear navigation history when navigate from edit page after confirm/done operation.
When navigate with android back button from car-list page it should exit the app (now it just goes back to car-edit page).