### PR TITLE
fix-next(android-images): fix images quality

### DIFF
--- a/cars/car-detail-page/car-detail-page.xml
+++ b/cars/car-detail-page/car-detail-page.xml
@@ -11,7 +11,7 @@
     <GridLayout class="page-content">
         <ScrollView>
             <GridLayout rows="auto, auto, auto">
-                <Image src="{{ car.imageUrl }}" stretch="aspectFill" height="200" class="m-b-15" decodeHeight="200"/>
+                <Image src="{{ car.imageUrl }}" stretch="aspectFill" height="200" class="m-b-15"/>
 
                 <StackLayout row="1" class="hr-light m-t-15 m-b-15"></StackLayout>
 

--- a/cars/cars-list-page.xml
+++ b/cars/cars-list-page.xml
@@ -35,7 +35,7 @@
 
                         <StackLayout row="1" class="hr-light m-t-5 m-b-5" colSpan="2" />
 
-                        <Image row="2" src="{{ imageUrl }}" stretch="aspectFill" height="120" class="m-r-20" decodeHeight="120" />
+                        <Image row="2" src="{{ imageUrl }}" stretch="aspectFit" height="120" class="m-r-20" decodeHeight="120" />
 
                         <StackLayout row="2" col="1" verticalAlignment="center" class="list-group-item-text">
                             <Label class="p-b-10">


### PR DESCRIPTION
Depends on https://github.com/NativeScript/NativeScript/pull/5513

By removing `decodeHeight` from car details image we set max image width to match the screen size.